### PR TITLE
Script does not fail at login now

### DIFF
--- a/sendsms.py
+++ b/sendsms.py
@@ -54,7 +54,7 @@ if args.setup:
 #   config.set('Login','name',raw_input("Enter your Name:"))
     config.set('Auth','loginpage','http://fullonsms.com/login.php')
     config.set('Auth','logincheck','http://fullonsms.com/login.php')
-    config.set('Auth','logindone','http://fullonsms.com/home.php?Login=1')
+    config.set('Auth','logindone','http://fullonsms.com/landing_page.php')
     config.set('Auth','sendsms','http://fullonsms.com/home.php')
     config.set('Auth','sms_sent','http://fullonsms.com/MsgSent.php')
     with open(args.authfile, 'wb') as configfile:


### PR DESCRIPTION
After login is successful, Fullonsms, now, opens http://fullonsms.com/landing_page.php, instead of http://fullonsms.com/login.php?Login=1.

Appropriately changed configuration.
